### PR TITLE
Clarify number origin on instruction FX29

### DIFF
--- a/src/5-instr.md
+++ b/src/5-instr.md
@@ -704,7 +704,7 @@ match (digit1, digit2, digit3, digit4) {
 
 ### FX29 - Set I to Font Address
 
-This is another tricky instruction where it may not be clear how to progress at first. If you recall, we stored an array of font data at the very beginning of RAM when initializing the emulator. This instruction wants us to take in the number to print on screen (from 0 to 0xF), and store the RAM address of that sprite into the *I Register*. We are actually free to store those sprites anywhere we wanted, so long as we are consistent and point to them correctly here. However, we stored them in a very convenient location, at the beginning of RAM. Let me show you what I mean by printing out some of the sprites and their RAM locations.
+This is another tricky instruction where it may not be clear how to progress at first. If you recall, we stored an array of font data at the very beginning of RAM when initializing the emulator. This instruction wants us to take from VX a number to print on screen (from 0 to 0xF), and store the RAM address of that sprite into the *I Register*. We are actually free to store those sprites anywhere we wanted, so long as we are consistent and point to them correctly here. However, we stored them in a very convenient location, at the beginning of RAM. Let me show you what I mean by printing out some of the sprites and their RAM locations.
 
 | Character | RAM Address |
 | --------- | ----------- |


### PR DESCRIPTION
Hiyya! First of all, thanks for this guide and book! I just followed it to make my own version of the emulator, and while doign so it was not apparent from the description of instruction FX29 that the number comes from VX. I slightly reworded the sentences to explicitly mention this register.